### PR TITLE
Add shorthand break point handling functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Continue the execution of a stopped process.
 Show all interpreted modules.
 
 ### edbg:delete_break(Mod,Line) | edbg:disable_break(Mod,Line) | edbg:enable_break(Mod,Line)
+### edbg:bdel(Mod,Line) | edbg:boff(Mod,Line) | edbg:bon(Mod,Line)
 Delete/Disable/Enable a break point.
 
 ### edbg:load_all_breakpoints() | edbg:lab()

--- a/src/edbg.erl
+++ b/src/edbg.erl
@@ -17,8 +17,11 @@
          continue/1,
          continue/3,
          delete_break/2,
+         bdel/2,
          disable_break/2,
+         boff/2,
          enable_break/2,
+         bon/2,
          f/1,
          f/3,
          finish/1,
@@ -104,16 +107,19 @@ break(Mod, Line) ->
     save_all_breakpoints(),
     ok.
 
+bdel(Mod, Line) -> delete_break.
 delete_break(Mod, Line) ->
     ok = int:delete_break(Mod, Line),
     save_all_breakpoints(),
     ok.
 
+boff(Mod, Line) -> disable_break(Mod, Line).
 disable_break(Mod, Line) ->
     ok = int:disable_break(Mod, Line),
     save_all_breakpoints(),
     ok.
 
+bon(Mod, Line) -> enable_break(Mod, Line).
 enable_break(Mod, Line) ->
     ok = int:enable_break(Mod, Line),
     save_all_breakpoints(),


### PR DESCRIPTION
* edbg, new functions: bdel/2, boff/2, bon/2; short hand functions that
  deletes, disables, and enables break points, respectively.