### PR TITLE
Fixed debugger not finding source

### DIFF
--- a/src/edbg.erl
+++ b/src/edbg.erl
@@ -1408,12 +1408,21 @@ sep(Row) ->
 
 %% @private
 find_source(Mod) ->
-    {ok, Fname} = filelib:find_source(code:which(Mod)),
+    case filelib:find_source(code:which(Mod)) of
+        {ok, Fname} ->
+            Fname;
+        {error, _} ->
+            find_source_from_modinfo(Mod)
+    end.
     %% [Fname] = [Z || {source,Z} <-
     %%                     hd([X || {compile,X} <-
     %%                                  apply(Mod,module_info,[])])],
-    Fname.
 
+%% @private
+find_source_from_modinfo(Mod) ->
+    Cs = Mod:module_info(compile),
+    {source, Fname} = lists:keyfind(source, 1, Cs),
+    Fname.
 
 i2l(I) when is_integer(I) -> integer_to_list(I).
 b2l(B) when is_binary(B)  -> binary_to_list(B).


### PR DESCRIPTION
In case compiled beam file is located to not too common location, i.e. test/ebin relative to the source, edbg:i could fail with:

** exception error: no match of right hand side value {error,not_found}
     in function  edbg:find_source/1 (src/edbg.erl, line 1411)
     in call from edbg:i/2 (src/edbg.erl, line 466)

since filelib:find_source fail in that case.

Fixed by getting source path from module_info.   Not sure if it
is necessary to call filelib:find_source at all.

Fixes #10.
