### PR TITLE
Centralize shell history handling in edbg_shell_history

### DIFF
--- a/src/edbg.erl
+++ b/src/edbg.erl
@@ -1177,12 +1177,13 @@ find_var(Var, Bindings) ->
 
 prompt(Pid, Apid) when is_pid(Pid), is_pid(Apid) ->
     Prompt = "("++pid_to_list(Pid)++")> ",
+    edbg_shell_history:enable(),
     ploop(Apid, Prompt, _PrevCmd = []).
 
 %% @private
 ploop(Apid, Prompt, PrevCmd) ->
     %% Empty prompt repeats previous command
-    Cmd = case string:tokens(io:get_line(Prompt), "\n") of
+    Cmd = case string:tokens(edbg_shell_history:get_line(Prompt), "\n") of
                 []   -> PrevCmd;
                 Cmd0 -> Cmd0
           end,

--- a/src/edbg_shell_history.erl
+++ b/src/edbg_shell_history.erl
@@ -4,8 +4,11 @@
 %%% @doc The `edbg' shell (hisotry) prompt handling
 %%%
 %%% Since OTP-26 the Erlang shell was changed so that edbg's prompt-loop
-%%% is not added to the shell history. In OTP-28 a io:setopts will be
-%%% added as well but until then, the following code could be used.
+%%% is not added to the shell history.
+%%%
+%%% - OTP >= 28: use io:setopts([{line_history, true}]) + io:get_line/1
+%%% - OTP 26-27: use get_until IO protocol trick
+%%% - OTP < 26: plain io:get_line/1 works
 %%%
 %%% See the demo module at:
 %%% https://www.erlang.org/doc/apps/stdlib/io_protocol.html#input-requests
@@ -14,25 +17,76 @@
 -module(edbg_shell_history).
 
 -export([until_newline/3,
-         get_line/1
+         get_line/1,
+         get_line/2,
+         enable/0
         ]).
 
-until_newline(_ThisFar,eof,_MyStopCharacter) ->
-    {done,eof,[]};
-until_newline(ThisFar,CharList,MyStopCharacter) ->
+until_newline(_ThisFar, eof, _MyStopCharacter) ->
+    {done, eof, []};
+until_newline(ThisFar, CharList, MyStopCharacter) ->
     case
-        lists:splitwith(fun(X) -> X =/= MyStopCharacter end,  CharList)
+        lists:splitwith(fun(X) -> X =/= MyStopCharacter end, CharList)
     of
-        {L,[]} ->
-            {more,ThisFar++L};
-        {L2,[MyStopCharacter|Rest]} ->
-            {done,ThisFar++L2++[MyStopCharacter],Rest}
+        {L, []} ->
+            {more, ThisFar ++ L};
+        {L2, [MyStopCharacter | Rest]} ->
+            {done, ThisFar ++ L2 ++ [MyStopCharacter], Rest}
     end.
 
-get_line(Prompt) when is_atom(Prompt) ->
-    get_line(Prompt, group_leader()).
+%% @doc Enable shell history for the current process.
+%%
+%% On OTP >= 28 this calls io:setopts([{line_history, true}]).
+%% On older versions it is a no-op (the get_until trick is used
+%% transparently in get_line/1 instead).
+%% @end
+enable() ->
+    case otp_release() of
+        Vsn when Vsn >= 28 ->
+            io:setopts([{line_history, true}]);
+        _ ->
+            ok
+    end.
+
+%% @doc Read a line from the user, with shell history support.
+%%
+%% On OTP >= 28, assumes enable/0 has been called so that
+%% io:get_line adds input to shell history (with arrow key support).
+%% On OTP 26-27, uses the get_until IO protocol request.
+%% On older OTP versions, plain io:get_line/1 is used.
+%% The Prompt can be either a string or an atom.
+%% @end
+get_line(Prompt) ->
+    case otp_release() of
+        Vsn when Vsn >= 28 ->
+            %% io:setopts([{line_history, true}]) should have been
+            %% called via enable/0 before entering the prompt loop.
+            io:get_line(Prompt);
+        Vsn when Vsn >= 26 ->
+            get_line_via_protocol(to_atom(Prompt));
+        _ ->
+            io:get_line(Prompt)
+    end.
 
 get_line(Prompt, IoServer) when is_atom(Prompt) ->
+    get_line_via_protocol(Prompt, IoServer).
+
+%%--------------------------------------------------------------------
+%% Internal
+%%--------------------------------------------------------------------
+
+otp_release() ->
+    try list_to_integer(erlang:system_info(otp_release))
+    catch _:_ -> 0
+    end.
+
+to_atom(Prompt) when is_atom(Prompt) -> Prompt;
+to_atom(Prompt) when is_list(Prompt) -> list_to_atom(Prompt).
+
+get_line_via_protocol(Prompt) when is_atom(Prompt) ->
+    get_line_via_protocol(Prompt, group_leader()).
+
+get_line_via_protocol(Prompt, IoServer) when is_atom(Prompt) ->
     IoServer ! {io_request,
                 self(),
                 IoServer,

--- a/src/edbg_sup_trees.erl
+++ b/src/edbg_sup_trees.erl
@@ -235,6 +235,7 @@ ploop(Prompt) ->
 
 prompt(Pid) when is_pid(Pid) ->
     process_flag(trap_exit, true),
+    edbg_shell_history:enable(),
     State0 = refresh(),
     State = help(show(State0)),
     loop(Pid, prompt(), State).
@@ -244,7 +245,7 @@ prompt(Pid) when is_pid(Pid) ->
 loop(Pid, Prompt, State0) ->
     io:format("~n",[]),
     State =
-        case string:tokens(b2l(io:get_line(Prompt)), "\n") of
+        case string:tokens(b2l(edbg_shell_history:get_line(Prompt)), "\n") of
             ["h"++X]  -> help(X, State0);
             ["x"++X]  -> help(expand(X, State0));
             ["s"++X]  -> shrink_or_show(X, State0);

--- a/src/edbg_tracer.erl
+++ b/src/edbg_tracer.erl
@@ -478,27 +478,13 @@ ploop(Prompt) ->
 
 prompt(Pid) when is_pid(Pid) ->
     Prompt = "tlist> ",
+    edbg_shell_history:enable(),
     rloop(Pid, Prompt).
-
-%%% Since OTP-26 the Erlang shell was changed so that edbg's
-%%% old prompt-loop (using io:get_line/1) will not have the
-%%% input added to the shell history.
-%%% This code try to solve this.
-get_line(Prompt) when is_list(Prompt) ->
-    try list_to_integer(erlang:system_info(otp_release)) of
-        Vsn when Vsn >= 26 ->
-            edbg_shell_history:get_line(list_to_atom(Prompt));
-        _ ->
-            io:get_line(Prompt)
-    catch
-        _:_ ->
-            io:get_line(Prompt)
-    end.
 
 
 %% @private
 rloop(Pid, Prompt) ->
-    case string:tokens(b2l(get_line(Prompt)), "\n") of
+    case string:tokens(b2l(edbg_shell_history:get_line(Prompt)), "\n") of
         ["eval"++X]  -> xeval(?mytracer, X);
         ["xnall"++X] -> xnall(?mytracer, X);
         ["xall"++X]  -> xall(?mytracer, X);


### PR DESCRIPTION
Add OTP version dispatching so callers no longer need to know which IO mechanism to use: OTP >= 28 uses io:setopts + io:get_line, OTP 26-27 uses the get_until IO protocol trick, and older releases fall back to plain io:get_line.

* src/edbg_shell_history.erl (enable, get_line/1, otp_release) (to_atom, get_line_via_protocol): Add enable/0 for OTP-28 line_history opt-in, version-dispatching get_line/1 that accepts strings, and internal helpers.  Reformat whitespace in until_newline/3.  Update module docstring.
* src/edbg.erl (prompt, ploop): Call edbg_shell_history:enable/0 on entry and use edbg_shell_history:get_line/1 instead of io:get_line/1.
* src/edbg_sup_trees.erl (prompt, loop): Same.
* src/edbg_tracer.erl (prompt, rloop): Same, and remove the now-redundant local get_line/1 helper.