### PR TITLE
Fix compilation error in edbg_sup_trees.erl

### DIFF
--- a/src/edbg_sup_trees.erl
+++ b/src/edbg_sup_trees.erl
@@ -152,7 +152,8 @@
         , start/0
         , supervisors/0
         , supervisors/1
-        ]).
+        , ploop/1
+    ]).
 
 
 -define(SERVER, ?MODULE).


### PR DESCRIPTION
Error on compilation:
      ┌─ src/edbg_sup_trees.erl:
     │
 233 │              ?MODULE:ploop(Prompt)
     │               ╰── Warning: function edbg_sup_trees:ploop/1 is not exported

Fixed by exporting edbg_sup_trees:ploop/1